### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Saleem Hadad, Binary Torch
 maintainer=Saleem <saleem@binary-torch.com>
 sentence=High level custom C++ based Arduino library
 paragraph=This library provide you many classes ready to use in your applications, like blinky, GPIO and many more..
-category=higher level control
+category=Other
 url=https://github.com/saleem-hadad/zino
 architectures=avr


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'higher level control' in library Zino is not valid. Setting to 'Uncategorized'
```
on every compilation.

See:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format